### PR TITLE
Added config for directives

### DIFF
--- a/config/easyblade.php
+++ b/config/easyblade.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+    'directives' => [
+        'route'            => \EasyBlade\Directives\RouteDirective::class,
+        'url'              => \EasyBlade\Directives\UrlDirective::class,
+        'asset'            => \EasyBlade\Directives\AssetDirective::class,
+        'isActive'         => \EasyBlade\Directives\isActiveDirective::class,
+        'count'            => \EasyBlade\Directives\CountDirective::class,
+        'endcount'         => \EasyBlade\Directives\EndConditionDirective::class,
+        'user'             => \EasyBlade\Directives\UserDirective::class,
+        'sessionExists'    => \EasyBlade\Directives\SessionExistsDirective::class,
+        'endsessionExists' => \EasyBlade\Directives\EndConditionDirective::class,
+        'session'          => \EasyBlade\Directives\SessionDirective::class,
+        'image'            => \EasyBlade\Directives\ImageDirective::class,
+        'style'            => \EasyBlade\Directives\StyleDirective::class,
+        'script'           => \EasyBlade\Directives\ScriptDirective::class,
+        'config'           => \EasyBlade\Directives\ConfigDirective::class,
+        'old'              => \EasyBlade\Directives\OldDirective::class,
+    ]
+];

--- a/src/EasyBladeServiceProvider.php
+++ b/src/EasyBladeServiceProvider.php
@@ -2,54 +2,30 @@
 
 namespace EasyBlade;
 
-use EasyBlade\Directives\{
-    OldDirective,
-    UrlDirective,
-    UserDirective,
-    AssetDirective,
-    CountDirective,
-    ImageDirective,
-    RouteDirective,
-    StyleDirective,
-    ConfigDirective,
-    ScriptDirective,
-    SessionDirective,
-    isActiveDirective,
-    EndConditionDirective,
-    SessionExistsDirective
-};
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 
-
 class EasyBladeServiceProvider extends ServiceProvider
 {
-    const DIRECTIVES = [
-        'route'            => RouteDirective::class,
-        'url'              => UrlDirective::class,
-        'asset'            => AssetDirective::class,
-        'isActive'         => isActiveDirective::class,
-        'count'            => CountDirective::class,
-        'endcount'         => EndConditionDirective::class,
-        'user'             => UserDirective::class,
-        'sessionExists'    => SessionExistsDirective::class,
-        'endsessionExists' => EndConditionDirective::class,
-        'session'          => SessionDirective::class,
-        'image'            => ImageDirective::class,
-        'style'            => StyleDirective::class,
-        'script'           => ScriptDirective::class,
-        'config'           => ConfigDirective::class,
-        'old'              => OldDirective::class,
-    ];
+    public function register(): void
+    {
+        $this->mergeConfigFrom(
+            __DIR__.'/../config/easyblade.php', 'easyblade'
+        );
+    }
 
     public function boot()
     {
+        $this->publishes([
+            __DIR__.'/../config/easyblade.php' => config_path('easyblade.php'),
+        ]);
+        
         $this->registerDirectives();
     }
 
     public function registerDirectives()
     {
-        foreach (static::DIRECTIVES as $directive => $class) {
+        foreach (config('easyblade.directives', []) as $directive => $class) {
             Blade::directive($directive, [$class, 'handle']);
         }
     }


### PR DESCRIPTION
Dear Reza,

Laravel 10 comes with a built-in [@style](https://laravel.com/docs/10.x/blade#conditional-classes) directive. However, your implementation serves a different purpose.

I utilize Laravel-Easyblade for my frontend and Filament for my backend. However, Filament employs the default @style directive.
Hence, I've extracted these directives into a configuration file. This allows everyone to choose which directive they prefer to use.

And with the config, I can easily create new directives without modifinging my AppServiceProvider.

Greetings C14r